### PR TITLE
Add failing test case for collapsing queries

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -4,21 +4,23 @@ const config = require('./config')
 const logger = require('winston')
 
 const collapseWhenSingleClause = (query) => {
-  if (query['$and']) {
-    if (query['$and'].length === 1) {
-      query = collapseWhenSingleClause(query['$and'][0])
-    } else {
-      query['$and'].forEach((obj, index, array) => {
-        array[index] = collapseWhenSingleClause(obj)
-      })
-    }
-  } else if (query['$or']) {
-    if (query['$or'].length === 1) {
-      query = collapseWhenSingleClause(query['$or'][0])
-    } else {
-      query['$or'].forEach((obj, index, array) => {
-        array[index] = collapseWhenSingleClause(obj)
-      })
+  for (const mainKey in query) {
+    if (Array.isArray(query[mainKey])) {
+      if (query[mainKey].length === 1) {
+        if (Object.keys(query).length === 1) {
+          query = collapseWhenSingleClause(query[mainKey][0])
+        } else {
+          const newObj = collapseWhenSingleClause(query[mainKey][0])
+          for (const key in newObj) {
+            query[key] = newObj[key]
+          }
+          delete query[mainKey] // delete original key/value
+        }
+      } else {
+        query[mainKey].forEach((obj, index, array) => {
+          array[index] = collapseWhenSingleClause(obj)
+        })
+      }
     }
   }
 

--- a/test/mongo.js
+++ b/test/mongo.js
@@ -22,8 +22,36 @@ tap.test('.util .collapseWhenSingleClause should collapse multiple single clause
       { field2: 'hello2' }
     ]
   }
-
   t.deepEqual(mongo.util.collapseWhenSingleClause(query), { field1: 'hello1', field2: 'hello2' })
+  t.end()
+})
+
+tap.test('.util .collapseWhenSingleClause should collapse multiple multiple clauses', (t) => {
+  const query = {
+    $and: [
+      { field1: 'hello1' }
+    ],
+    $or: [
+      { field2: 'hello2' },
+      { field3: 'hello3' }
+    ]
+  }
+  t.deepEqual(mongo.util.collapseWhenSingleClause(query), { field1: 'hello1', $or: [ { field2: 'hello2' }, { field3: 'hello3' } ] })
+  t.end()
+})
+
+tap.test('.util .collapseWhenSingleClause should collapse multiple multiple clauses', (t) => {
+  const query = {
+    $and: [
+      { field1: 'hello1' },
+      { field2: 'hello2' }
+    ],
+    $or: [
+      { field3: 'hello3' },
+      { field4: 'hello4' }
+    ]
+  }
+  t.deepEqual(mongo.util.collapseWhenSingleClause(query), { $and: [ { field1: 'hello1' }, { field2: 'hello2' } ], $or: [ { field3: 'hello3' }, { field4: 'hello4' } ] })
   t.end()
 })
 


### PR DESCRIPTION
Add a test case for when both the $and and $or operators are used in a
single query.