### PR TITLE
Restrict users to only read and update themselves

### DIFF
--- a/lib/plugins/default.js
+++ b/lib/plugins/default.js
@@ -23,7 +23,8 @@ module.exports = () => {
         ],
 
         // N/A as the sysadmin can anyway access all
-        allowBreakTheGlass: false
+        allowBreakTheGlass: false,
+        allowUserManagement: true
       }
     },
 

--- a/lib/security/authorization.js
+++ b/lib/security/authorization.js
@@ -15,6 +15,20 @@ const userTypeRestrictions = {}
 module.exports = (mongo) => {
   let fhirCommon = FhirCommon(mongo)
 
+  const isUserManagementRequestValid = (interaction, ctx, authorizer) => {
+    switch (interaction) {
+      case 'create':
+        return true
+      case 'read':
+      case 'update':
+        return ctx.authenticatedUser.email === ctx.url.split('/').pop() || authorizer.allowUserManagement
+      case 'search':
+        return authorizer.allowUserManagement === true
+    }
+
+    return false
+  }
+
   return {
     addUserTypeRestrictions: (userTypeRestrictionsToAdd) => {
       Object.assign(userTypeRestrictions, userTypeRestrictionsToAdd)
@@ -72,6 +86,10 @@ module.exports = (mongo) => {
           logger.warn(`${authenticatedUser.email} used break the glass header for '${interaction} ${ctx.url}'. Header will be ignored.`)
           // treat as normal
         }
+      }
+
+      if (resourceType === 'user' && !isUserManagementRequestValid(interaction, ctx, authorizer)) {
+        return sendForbidden()
       }
 
       for (let type of authorizer.allowedResourceTypes) {

--- a/test/test-env/init.js
+++ b/test/test-env/init.js
@@ -355,6 +355,12 @@ module.exports = () => {
           salt: '08f3a235-8660-49e9-93c3-5d4655b98c83',
           type: 'sysadmin',
           locked: true
+        },
+        megan: {
+          email: 'megan@test.org',
+          hash: '4956a991e772edd0576e62eae92f9c94fc693a2d0ee07f8f46ccce9c343d0836304f4de2ea64a41932fe0a6adc83d853a964fb785930fb4293fef8ee37448ac8',
+          salt: '08f3a235-8660-49e9-93c3-5d4655b98c83',
+          type: 'user'
         }
       }
     },


### PR DESCRIPTION
This change restircts nrmal user from reading or updating anyone other
than themselves. It also introduces a allowUserMangement priviledge that
allows certain users to be able to manage all users.

ANSA-691