### PR TITLE
Updated the FHIR package version with a patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cors": "^2.8.1",
     "express": "^4.16.3",
     "express-xml-bodyparser": "^0.3.0",
-    "fhir": "^3.3.0",
+    "fhir": "^3.3.1",
     "jsonwebtoken": "^8.2.2",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1697,9 +1697,9 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fhir@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/fhir/-/fhir-3.3.0.tgz#17945542e661869867820c73e9cf92ca293192bf"
+fhir@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fhir/-/fhir-3.3.1.tgz#dbc0f2edc8096225af6e659041a686a4419c13ad"
   dependencies:
     libxmljs "0.18.0"
     lodash "^3.10.1"


### PR DESCRIPTION
This patch includes a fix for the FHIR validation where Boolean values where not being validated correctly, and needed to be represented as strings, This is not correct according to the FHIR spec, and this Patch fix addressed this issue