### PR TITLE
[HC-797] CLI to generate JWT authentication tokens for service auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,33 @@ View the possible config fields [here](https://github.com/jembi/hearth/blob/mast
 * Patient Demographics Query for mobile - ([PDQm](http://www.ihe.net/uploadedFiles/Documents/ITI/IHE_ITI_Suppl_PDQm.pdf))
 * Terminology Service `$lookup` operation - ([$lookup](https://www.hl7.org/fhir/DSTU2/valueset-operations.html#lookup))
 
+## Service-to-service Authentication
+
+Enable JWT authentication middleware by including the following configuration in your config file:
+
+```json
+"authentication": {
+  "type": "jwt",
+  "secret": "my secret"
+}
+```
+
+Generate an API token:
+
+```bash
+$ ./scripts/generate-api-token --service-name "My Service" --admin-email admin@my-service.org --secret "my secret"
+
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXJ2aWNlIjoiTXkgU2VydmljZSIsImVtYWlsIjoiYWRtaW5AbXktc2VydmljZS5vcmciLCJ0eXBlIjoic2VydmljZSIsImlhdCI6MTUzMjQyNjg2NywiaXNzIjoiSGVhcnRoIn0.bQomDjWkwSrTyYAiX917kiKZvbsh9httwqRGEMvqZak
+```
+
+Include the `Authorization` header in Hearth API calls with the Bearer token set to the token output by the script:
+
+```bash
+curl -X GET \\
+  https://myhearth.org/fhir/Person/222222 \\
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXJ2aWNlIjoiTXkgU2VydmljZSIsImVtYWlsIjoiYWRtaW5AbXktc2VydmljZS5vcmciLCJ0eXBlIjoic2VydmljZSIsImlhdCI6MTUzMjQyNjg2NywiaXNzIjoiSGVhcnRoIn0.bQomDjWkwSrTyYAiX917kiKZvbsh9httwqRGEMvqZak"
+```
+
 # Pro dev tips:
 * To run only specific test files use `yarn test:these-files test/pdqm.js`.
 * Run `yarn cov` to show coverage details in your browser.

--- a/lib/plugins/default.js
+++ b/lib/plugins/default.js
@@ -25,6 +25,17 @@ module.exports = () => {
         // N/A as the sysadmin can anyway access all
         allowBreakTheGlass: false,
         allowUserManagement: true
+      },
+      'service': {
+        allowedResourceTypes: [
+          {
+            resourceType: '*',
+            interactions: '*',
+            searchAllAllowed: true
+          }
+        ],
+        allowBreakTheGlass: false,
+        allowUserManagement: true
       }
     },
 

--- a/scripts/generate-api-token.js
+++ b/scripts/generate-api-token.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const jwt = require('jsonwebtoken')
+const cli = require('./util/cli')
+
+const renderCliMessage = () => {
+  const message = `generate-api-token
+
+Generate an API token for service-to-service communication.
+
+Usage:
+
+$ ./scripts/generate-api-token.js --service-name "My Service" --admin-email admin@my-service.org --secret "my secret"
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXJ2aWNlIjoiTXkgU2VydmljZSIsImVtYWlsIjoiYWRtaW5AbXktc2VydmljZS5vcmciLCJ0eXBlIjoic2VydmljZSIsImlhdCI6MTUzMjQyNjg2NywiaXNzIjoiSGVhcnRoIn0.bQomDjWkwSrTyYAiX917kiKZvbsh9httwqRGEMvqZak
+
+curl -X GET \\
+  https://myhearth.org/fhir/Person/222222 \\
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXJ2aWNlIjoiTXkgU2VydmljZSIsImVtYWlsIjoiYWRtaW5AbXktc2VydmljZS5vcmciLCJ0eXBlIjoic2VydmljZSIsImlhdCI6MTUzMjQyNjg2NywiaXNzIjoiSGVhcnRoIn0.bQomDjWkwSrTyYAiX917kiKZvbsh9httwqRGEMvqZak"
+
+Arguments:
+
+-n --service-name\tService name
+-e --admin-email\tService administrator email
+-s --secret\t\tSecret or private key`
+
+  console.log(
+      message
+        .split('\n')
+        .map(line => `\t${line}`)
+        .join('\n')
+    )
+
+  process.exit()
+}
+
+const renderErrorMessage = error => {
+  console.error(error.message || error)
+  process.exit(1)
+}
+
+const handleInvalidInput = error => {
+  if (error) {
+    renderErrorMessage(error)
+  } else {
+    renderCliMessage()
+  }
+}
+
+const processInput = cli(
+  [
+    [/^(-n|--service-name)$/, 'serviceName'],
+    [/^(-e|--admin-email)$/, 'adminEmail'],
+    [/^(-s|--secret)$/, 'secretOrPrivateKey']
+  ],
+  handleInvalidInput
+)
+
+const {
+  serviceName,
+  adminEmail,
+  secretOrPrivateKey
+} = processInput(process.argv)
+
+if (!serviceName || !adminEmail || !secretOrPrivateKey) {
+  renderErrorMessage('Service name, administrator email and secret are required')
+}
+
+const payload = {
+  service: serviceName,
+  email: adminEmail,
+  type: 'service'
+}
+const options = {issuer: 'Hearth'}
+
+jwt.sign(payload, secretOrPrivateKey, options, (err, token) => {
+  if (err) {
+    throw err
+  }
+  console.log(token)
+})

--- a/scripts/util/cli.js
+++ b/scripts/util/cli.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const NOOP_HANDLER = () => {}
+
+const cli = (availableOptions, onInvalidInput = NOOP_HANDLER) =>
+  ([n, script, ...args]) => {
+    const invalidArguments = []
+    const mapOptions = input => {
+      const option = availableOptions.find(([regex]) => regex.exec(input))
+      if (!option) {
+        invalidArguments.push(input)
+      }
+      return option && option[1]
+    }
+
+    const options = args
+      .filter((x, i) => i % 2 === 0)
+      .map(mapOptions)
+      .filter(x => !!x)
+
+    if (invalidArguments.length > 0) {
+      return onInvalidInput(new Error(`Invalid option ${invalidArguments.join(', ')}`))
+    } else if (options.length === 0) {
+      return onInvalidInput()
+    }
+
+    const values = args.filter((x, i) => i % 2 !== 0)
+
+    return options
+      .map((option, i) => ({ [option]: values[i] }))
+      .reduce((acc, option) => Object.assign({}, acc, option), {})
+  }
+
+module.exports = cli

--- a/test/scripts/cli.js
+++ b/test/scripts/cli.js
@@ -1,0 +1,63 @@
+const tap = require('tap')
+const sinon = require('sinon')
+
+const cli = require('../../scripts/util/cli')
+
+const autoend = {autoend: true}
+
+const fakeArgv = args => [null, null, ...args]
+
+tap.test('CLI', autoend, t => {
+  t.test('should zip arguments with their respective values', autoend, t => {
+    const processInput = cli([
+      [/--foo/, 'foo']
+    ])
+    t.deepEqual(
+      processInput(fakeArgv(['--foo', 'bar'])),
+      { foo: 'bar' }
+    )
+  })
+
+  t.test('should zip the correct arguments with their respective values', autoend, t => {
+    const processInput = cli([
+      [/--foo/, 'foo'],
+      [/--bar/, 'bar'],
+      [/--baz/, 'baz']
+    ])
+    t.deepEqual(
+      processInput(fakeArgv(['--foo', 'bar', '--baz', 'foobar'])),
+      {
+        foo: 'bar',
+        baz: 'foobar'
+      }
+    )
+  })
+
+  t.test('should call callback with an error when incorrect arguments are provided', autoend, t => {
+    const stub = sinon.stub()
+    const processInput = cli([], stub)
+    processInput(fakeArgv(['--foo', 'bar']))
+    t.equal(stub.calledOnce, true)
+    const errorArg = stub.args[0][0]
+    t.type(errorArg, Error)
+    t.equal(errorArg.message, 'Invalid option --foo')
+  })
+
+  t.test('should call callback with an error when multiple incorrect arguments are provided', autoend, t => {
+    const stub = sinon.stub()
+    const processInput = cli([], stub)
+    processInput(fakeArgv(['--foo', 'bar', '--bar', 'baz']))
+    t.equal(stub.calledOnce, true)
+    const errorArg = stub.args[0][0]
+    t.type(errorArg, Error)
+    t.equal(errorArg.message, 'Invalid option --foo, --bar')
+  })
+
+  t.test('should call callback with no arguments when no arguments are provided', autoend, t => {
+    const stub = sinon.stub()
+    const processInput = cli([], stub)
+    processInput(fakeArgv([]))
+    t.equal(stub.calledOnce, true)
+    t.equal(stub.args[0][0], undefined)
+  })
+})


### PR DESCRIPTION
CLI to manually generate JWT authentication tokens for secure service-to-service communication.

As of this change, we're not tracking these tokens server-side, therefore there's no way to revoke a token once issued except to change the signature secret. 

Update:

Added config for `"service"` user type restrictions to allow unrestricted access for services. 