### PR TITLE
Don't log MongoDB connection string

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -49,7 +49,7 @@ module.exports = () => {
       }
 
       const mongoUrl = config.getConf('mongodb:url')
-      logger.info(`Initializing MongoDB connection to ${mongoUrl}`)
+      logger.info('Initializing MongoDB connection')
       MongoClient.connect(mongoUrl, (err, database) => {
         if (err) {
           return callback(err)


### PR DESCRIPTION
The URL used to connect to MongoDB may contain auth information so for
security reasons it should not be logged. We're seeing this where we have Hearth deployed in one of our test environments.