### PR TITLE
Remove default value for optional field validateAudience

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -16,9 +16,9 @@
       "secret": null,
       "privKey": null,
       "pubKey": null,
-      "issuer": "hearth",
+      "issuer": "Hearth",
       "setAudience": "hearth/example-app1",
-      "validateAudience": "^hearth:example-app\\d+$",
+      "validateAudience": null,
       "expiresIn": "1d"
     }
   },


### PR DESCRIPTION
This sets the config item `validateAudience` as optional by removing the default value configured in default.json.