### PR TITLE
Allow PUT requests to update or insert records, as required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "lts/dubnium"
 matrix:
   allow_failures:
-    - node_js: "lts/dubmium"
+    - node_js: "lts/dubnium"
 dist: xenial
 services:
   - mongodb
@@ -19,7 +19,7 @@ addon:
 notifications:
   slack:
     rooms:
-      - jembihealthsystems:mlQYVFbijxcZkesCt7G5VBoM
+      - jembihealthsystems:6VZdEFjN6eL1ZXL4Totf8wOY#hearth-alerts
     on_success: change
     on_failure: always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "lts/carbon"
-  - "lts/dubnium"
+#  - "lts/dubnium"
 dist: xenial
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 node_js:
   - "lts/carbon"
-#  - "lts/dubnium"
+  - "lts/dubnium"
+matrix:
+  allow_failures:
+    - node_js: "lts/dubmium"
 dist: xenial
 services:
   - mongodb
@@ -9,5 +12,14 @@ after_success:
   - npm run test:upload-cov
   - npm run test:load
   - ".travis/build_docker.sh"
+before_install:
+  - export TZ=Africa/Johannesburg
 addon:
   srcclr: true
+notifications:
+  slack:
+    rooms:
+      - jembihealthsystems:mlQYVFbijxcZkesCt7G5VBoM
+    on_success: change
+    on_failure: always
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "lts/boron"
   - "lts/carbon"
+  - "lts/dubnium"
 dist: xenial
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 matrix:
   allow_failures:
     - node_js: "lts/dubnium"
-dist: xenial
+dist: bionic
 services:
   - mongodb
 after_success:

--- a/config/config.md
+++ b/config/config.md
@@ -40,4 +40,5 @@ See an example file [here](default.json).
 * `matchingQueue.pollingInterval` e.g. 1000 - how often to poll for new record to be matched, in ms.
 * `validation.enabled` e.g. false - whether to enable basic resource validation.
 * `validation.additionProfilePaths` e.g. [ 'lib/fhir/profiles/mhd' ] - array of paths to profiles that you want to make the validation module aware of.
+* `operations.upserting` e.g. false(default) or true - whether to enable inserting if a record doesn't already exist for update operations.
 * `knownIdentityDomains` e.g. [ 'some:identity:domain' ] - an array of identify domains that are known to the PIXm profile. Only necessary if you are using this IHE profile.

--- a/config/config.md
+++ b/config/config.md
@@ -40,5 +40,5 @@ See an example file [here](default.json).
 * `matchingQueue.pollingInterval` e.g. 1000 - how often to poll for new record to be matched, in ms.
 * `validation.enabled` e.g. false - whether to enable basic resource validation.
 * `validation.additionProfilePaths` e.g. [ 'lib/fhir/profiles/mhd' ] - array of paths to profiles that you want to make the validation module aware of.
-* `operations.upserting` e.g. false(default) or true - whether to enable inserting if a record doesn't already exist for update operations.
+* `operations.upsert` e.g. false (default) or true - whether to enable inserting if a record doesn't already exist for update operations.
 * `knownIdentityDomains` e.g. [ 'some:identity:domain' ] - an array of identify domains that are known to the PIXm profile. Only necessary if you are using this IHE profile.

--- a/config/default.json
+++ b/config/default.json
@@ -47,5 +47,8 @@
       "lib/fhir/profiles/mhd"
     ]
   },
+  "operations": {
+    "upserting": false
+  },
   "knownIdentityDomains": []
 }

--- a/config/default.json
+++ b/config/default.json
@@ -48,7 +48,7 @@
     ]
   },
   "operations": {
-    "upserting": false
+    "upsert": false
   },
   "knownIdentityDomains": []
 }

--- a/lib/fhir/core.js
+++ b/lib/fhir/core.js
@@ -563,7 +563,7 @@ module.exports = (mongo, modules) => {
 
               c.findOneAndReplace({
                 id: id
-              }, resource, options, async (err, result) => {
+              }, resource, options, (err, result) => {
                 if (err) {
                   return callback(err)
                 }

--- a/lib/fhir/core.js
+++ b/lib/fhir/core.js
@@ -556,8 +556,8 @@ module.exports = (mongo, modules) => {
               resource.meta.versionId = fhirCommon.util.generateID()
 
               const options = {
-                upsert: false, // TODO OHIE-168
-                returnOriginal: true
+                upsert: true,
+                returnOriginal: false
               }
 
               c.findOneAndReplace({
@@ -572,6 +572,7 @@ module.exports = (mongo, modules) => {
                 }
 
                 delete result.value._id
+console.log('result='+JSON.stringify(result))
 
                 const cHistory = db.collection(`${resourceType}_history`)
                 cHistory.insert(result.value, (err) => {

--- a/lib/fhir/core.js
+++ b/lib/fhir/core.js
@@ -572,7 +572,6 @@ module.exports = (mongo, modules) => {
                 }
 
                 delete result.value._id
-console.log('result='+JSON.stringify(result))
 
                 const cHistory = db.collection(`${resourceType}_history`)
                 cHistory.insert(result.value, (err) => {

--- a/lib/fhir/core.js
+++ b/lib/fhir/core.js
@@ -13,6 +13,7 @@ const FhirCommon = require('./common')
 const Authorization = require('../security/authorization')
 const Hooks = require('./hooks')
 const matchingConfig = require('../../config/matching')
+const config = require('../config')
 
 const handleErrorAndBadRequest = (err, badRequest, callback) => {
   if (err) {
@@ -556,15 +557,19 @@ module.exports = (mongo, modules) => {
               resource.meta.versionId = fhirCommon.util.generateID()
 
               const options = {
-                upsert: true,
-                returnOriginal: false
+                upsert: config.getConf('operations:upserting'),
+                returnOriginal: true
               }
 
               c.findOneAndReplace({
                 id: id
-              }, resource, options, (err, result) => {
+              }, resource, options, async (err, result) => {
                 if (err) {
                   return callback(err)
+                }
+
+                if (!result.value && options.upsert) {
+                  return callback(null, { httpStatus: 201, id: resource.id })
                 }
 
                 if (!result.value) {

--- a/lib/fhir/core.js
+++ b/lib/fhir/core.js
@@ -557,7 +557,7 @@ module.exports = (mongo, modules) => {
               resource.meta.versionId = fhirCommon.util.generateID()
 
               const options = {
-                upsert: config.getConf('operations:upserting'),
+                upsert: config.getConf('operations:upsert') || false,
                 returnOriginal: true
               }
 
@@ -569,7 +569,14 @@ module.exports = (mongo, modules) => {
                 }
 
                 if (!result.value && options.upsert) {
-                  return callback(null, { httpStatus: 201, id: resource.id })
+                  return hooks.executeAfterHooks('create', fhirModule, ctx, resourceType, resource, (err, badRequest) => {
+                    if (err || badRequest) {
+                      return handleErrorAndBadRequest(err, badRequest, callback)
+                    }
+
+                    const location = `/fhir/${resourceType}/${resource.id}/_history/${resource.meta.versionId}`
+                    callback(null, { httpStatus: 201, location: location, etag: resource.meta.versionId, id: resource.id })
+                  })
                 }
 
                 if (!result.value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hearth",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-beta.1",
   "description": "Hearth, a home for FHIR. A fast FHIR-compliant server.",
   "scripts": {
     "start": "node lib/server.js",

--- a/test/patient.js
+++ b/test/patient.js
@@ -1963,8 +1963,8 @@ tap.test('patient update should insert document when upsert true and document do
         env.clearDB((err) => {
           t.error(err)
           server.stop(() => {
-            t.end()
             config.setConf('operations:upserting', false)
+            t.end()
           })
         })
       })

--- a/test/patient.js
+++ b/test/patient.js
@@ -1946,7 +1946,7 @@ tap.test('patient update should insert document when upsert true and document do
     server.start((err) => {
       t.error(err)
 
-      config.setConf('operations:upserting', true)
+      config.setConf('operations:upsert', true)
 
       const pat = _.cloneDeep(require('./resources/Patient-1.json'))
 
@@ -1963,7 +1963,7 @@ tap.test('patient update should insert document when upsert true and document do
         env.clearDB((err) => {
           t.error(err)
           server.stop(() => {
-            config.setConf('operations:upserting', false)
+            config.setConf('operations:upsert', false)
             t.end()
           })
         })
@@ -1978,6 +1978,8 @@ tap.test('patient update should error when upsert false and document does not ex
 
     server.start((err) => {
       t.error(err)
+
+      config.setConf('operations:upsert', false)
 
       const pat = _.cloneDeep(require('./resources/Patient-1.json'))
 


### PR DESCRIPTION
Prior to this change, requests to the PUT endpoint updated existing
records and returned a 404 response when the requested record did not
exist. This change will prevent having to make two distinct calls
when a requested record isn't found and ensure that the supplied
value for 'id' is assigned to the inserted record.

This change will update an existing record on request; if the record
does not already exist, it will be inserted and response 201
returned.

IHS-121