### PR TITLE
IHS-123 Allow string-type parameter for upsert flag

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -40,5 +40,5 @@ See an example file [here](default.json).
 * `matchingQueue.pollingInterval` e.g. 1000 - how often to poll for new record to be matched, in ms.
 * `validation.enabled` e.g. false - whether to enable basic resource validation.
 * `validation.additionProfilePaths` e.g. [ 'lib/fhir/profiles/mhd' ] - array of paths to profiles that you want to make the validation module aware of.
-* `operations.upsert` e.g. false (default) or true - whether to enable inserting if a record doesn't already exist for update operations.
+* `operations.updateCreate` e.g. false (default) or true - whether to enable inserting if a record doesn't already exist for update operations.
 * `knownIdentityDomains` e.g. [ 'some:identity:domain' ] - an array of identify domains that are known to the PIXm profile. Only necessary if you are using this IHE profile.

--- a/config/default.json
+++ b/config/default.json
@@ -48,7 +48,7 @@
     ]
   },
   "operations": {
-    "upsert": false
+    "updateCreate": false
   },
   "knownIdentityDomains": []
 }

--- a/lib/fhir/core.js
+++ b/lib/fhir/core.js
@@ -557,8 +557,19 @@ module.exports = (mongo, modules) => {
               resource.meta.versionId = fhirCommon.util.generateID()
 
               const options = {
-                upsert: config.getConf('operations:upsert') || false,
+                upsert: false,
                 returnOriginal: true
+              }
+
+              const op = config.getConf('operations:updateCreate')
+              if (typeof op !== 'boolean') {
+                logger.debug(`'operations:updateCreate' is not a boolean value`)
+              }
+
+              if ((typeof op === 'string') && (op === 'true')) {
+                options.upsert = true
+              } else if (typeof op === 'boolean') {
+                options.upsert = op
               }
 
               c.findOneAndReplace({
@@ -568,7 +579,7 @@ module.exports = (mongo, modules) => {
                   return callback(err)
                 }
 
-                if (!result.value && options.upsert) {
+                if (options.upsert && result.lastErrorObject.n === 1 && !result.lastErrorObject.updatedExisting) {
                   return hooks.executeAfterHooks('create', fhirModule, ctx, resourceType, resource, (err, badRequest) => {
                     if (err || badRequest) {
                       return handleErrorAndBadRequest(err, badRequest, callback)

--- a/test/patient.js
+++ b/test/patient.js
@@ -1939,7 +1939,7 @@ tap.test('patient should support standard _id parameter', (t) => {
   })
 })
 
-tap.test('patient update should insert document when updateCreate true and document does not exist', (t) => {
+tap.test('patient update should insert document when boolean updateCreate true and document does not exist', (t) => {
   env.initDB((err, db) => {
     t.error(err)
 
@@ -1972,7 +1972,40 @@ tap.test('patient update should insert document when updateCreate true and docum
   })
 })
 
-tap.test('patient update should error when updateCreate false and document does not exist', (t) => {
+tap.test('patient update should insert document when string updateCreate true and document does not exist', (t) => {
+  env.initDB((err, db) => {
+    t.error(err)
+
+    server.start((err) => {
+      t.error(err)
+
+      config.setConf('operations:updateCreate', 'true')
+
+      const pat = _.cloneDeep(require('./resources/Patient-1.json'))
+
+      request.put({
+        url: `http://localhost:3447/fhir/Patient/${pat.id}`,
+        headers: headers,
+        body: pat,
+        json: true
+      }, (err, res, body) => {
+        t.error(err)
+        t.equal(res.statusCode, 201, 'response status code should be 201')
+        t.ok(body)
+
+        env.clearDB((err) => {
+          t.error(err)
+          server.stop(() => {
+            config.setConf('operations:updateCreate', false)
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+tap.test('patient update should error when boolean updateCreate false and document does not exist', (t) => {
   env.initDB((err, db) => {
     t.error(err)
 
@@ -1980,6 +2013,38 @@ tap.test('patient update should error when updateCreate false and document does 
       t.error(err)
 
       config.setConf('operations:updateCreate', false)
+
+      const pat = _.cloneDeep(require('./resources/Patient-1.json'))
+
+      request.put({
+        url: `http://localhost:3447/fhir/Patient/${pat.id}`,
+        headers: headers,
+        body: pat,
+        json: true
+      }, (err, res, body) => {
+        t.error(err)
+        t.equal(res.statusCode, 404, 'response status code should be 404')
+        t.ok(body)
+
+        env.clearDB((err) => {
+          t.error(err)
+          server.stop(() => {
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+tap.test('patient update should error when string updateCreate false and document does not exist', (t) => {
+  env.initDB((err, db) => {
+    t.error(err)
+
+    server.start((err) => {
+      t.error(err)
+
+      config.setConf('operations:updateCreate', 'false')
 
       const pat = _.cloneDeep(require('./resources/Patient-1.json'))
 

--- a/test/patient.js
+++ b/test/patient.js
@@ -1939,14 +1939,14 @@ tap.test('patient should support standard _id parameter', (t) => {
   })
 })
 
-tap.test('patient update should insert document when upsert true and document does not exist', (t) => {
+tap.test('patient update should insert document when updateCreate true and document does not exist', (t) => {
   env.initDB((err, db) => {
     t.error(err)
 
     server.start((err) => {
       t.error(err)
 
-      config.setConf('operations:upsert', true)
+      config.setConf('operations:updateCreate', true)
 
       const pat = _.cloneDeep(require('./resources/Patient-1.json'))
 
@@ -1963,7 +1963,7 @@ tap.test('patient update should insert document when upsert true and document do
         env.clearDB((err) => {
           t.error(err)
           server.stop(() => {
-            config.setConf('operations:upsert', false)
+            config.setConf('operations:updateCreate', false)
             t.end()
           })
         })
@@ -1972,14 +1972,14 @@ tap.test('patient update should insert document when upsert true and document do
   })
 })
 
-tap.test('patient update should error when upsert false and document does not exist', (t) => {
+tap.test('patient update should error when updateCreate false and document does not exist', (t) => {
   env.initDB((err, db) => {
     t.error(err)
 
     server.start((err) => {
       t.error(err)
 
-      config.setConf('operations:upsert', false)
+      config.setConf('operations:updateCreate', false)
 
       const pat = _.cloneDeep(require('./resources/Patient-1.json'))
 


### PR DESCRIPTION
Prior to this change, environment variables received through the
environment were interpreted by nconf as strings.

This change allows the upsert flag to be passed in as string or
boolean data type.

Also, changes the name of the upsert flag in the configuration file to 'updateCreate'
